### PR TITLE
fix the bug that the using login instead of name

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error get bot name")
 	}
 
-	bName := strings.ToLower(v.Name)
+	bName := strings.ToLower(v.Login)
 
 	syncCli, err := sync.NewSynchronize(o.syncEndpoint, f(o.akPath), f(o.skPath), o.region, c, bName)
 	if err != nil {


### PR DESCRIPTION
it should use the robot's login instead of name to compare with the commenter's login.
For example: login name: I-am-a-robot, nickname: i-robot